### PR TITLE
28-create-in-cluster-config-option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All configuration options can be provided via the command line or as environment
 | `NATS_NAME_PREFIX`| `--nats-name-prefix` | A name label prefix. Sources should append a dot and their hostname .{hostname} to this, then set this is the NATS connection name which will be sent to the server on CONNECT to identify the client |
 | `NATS_JWT` | `--nats-jwt` | ✅ | The JWT token that should be used to authenticate to NATS, provided in raw format e.g. `eyJ0eXAiOiJKV1Q{...}` |
 | `NATS_NKEY_SEED` | `--nats-nkey-seed` | ✅ | The NKey seed which corresponds to the NATS JWT e.g. `SUAFK6QUC{...}` |
-| `KUBECONFIG`| `--kubeconfig` | Path to the kubeconfig file containing cluster details (default: `/etc/srcman/config/kubeconfig`) |
+| `KUBECONFIG`| `--kubeconfig` | Path to the kubeconfig file containing cluster details. If this is blank in-cluster config will be used |
 | `MAX-PARALLEL`| `--max-parallel` | Max number of requests to run in parallel |
 
 ### `srcman` config


### PR DESCRIPTION
Use in-cluster as the default. I'm still not sure how this will work overall, but that will be tracked in #34