### PR TITLE
38-create-helm-chart-to-deploy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,9 @@
 				"github.vscode-pull-request-github",
 				"golang.go",
 				"gruntfuggly.todo-tree",
-				"streetsidesoftware.code-spell-checker"
+				"streetsidesoftware.code-spell-checker",
+				"Tim-Koehler.helm-intellisense",
+				"ms-kubernetes-tools.vscode-kubernetes-tools",
 			]
 		}
 	},

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -4,8 +4,8 @@ go install sigs.k8s.io/kind@latest
 
 # Create the test cluster (the tests also do this) but also set local kube
 # config
-kind create cluster --name k8s-source-tests
-kind export kubeconfig --name k8s-source-tests
+kind create cluster --name local-tests
+kind export kubeconfig --name local-tests
 
 # Install k9s
 curl -sS https://webinstall.dev/k9s | bash

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,0 +1,33 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          charts_dir: deployments

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -53,6 +53,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          audience: sts.amazonaws.com # set default value to work around https://github.com/aws-actions/configure-aws-credentials/issues/271#issuecomment-1401481855
+          aws-region: eu-west-2
+          role-to-assume: ${{ vars.BUILDKIT_CONNECT_ARN }}
+
+      - name: Fetch EKS Configuration
+        run: |
+          aws eks update-kubeconfig --name dogfood
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -74,6 +85,16 @@ jobs:
       - name: Set up Docker Buildx
         id: setup-builder
         uses: docker/setup-buildx-action@v2
+        with:
+          driver: kubernetes
+          platforms: linux/amd64
+          driver-opts: |
+            namespace=buildkit,"nodeselector=kubernetes.io/arch=amd64",requests.cpu=0.9,requests.memory=1G,limits.memory=4G
+          append: |
+            - name: ${{ matrix.image_name }}-${{ github.run_id }}-${{ github.run_attempt }}-arm64
+              platforms: linux/arm64
+              driver-opts:
+                - namespace=buildkit,"nodeselector=kubernetes.io/arch=arm64",requests.cpu=0.9,requests.memory=1G,limits.memory=4G
 
       - name: Build and push
         id: push
@@ -87,3 +108,14 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Prepare Deployment
+        run: |
+          echo "ghcr.io/overmindtech/${{ matrix.image_name }}@${{ steps.push.outputs.digest }}" | tee ${{ matrix.image_name }}.imageref
+
+      - name: Upload Deployment File
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.image_name }}.imageref
+          path: ${{ matrix.image_name }}.imageref

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,8 @@
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"ms-vscode-remote.remote-containers",
+		"tim-koehler.helm-intellisense",
+		"ms-kubernetes-tools.vscode-kubernetes-tools"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/deployments/overmind-kube-source/.helmignore
+++ b/deployments/overmind-kube-source/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployments/overmind-kube-source/Chart.yaml
+++ b/deployments/overmind-kube-source/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: overmind-kube-source
+description: A source that allows Overmind to read from the current Kubernetes cluster
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "main"

--- a/deployments/overmind-kube-source/README.md
+++ b/deployments/overmind-kube-source/README.md
@@ -1,0 +1,15 @@
+# K8s Source Helm Chart
+
+## Developing
+
+Installing into a local cluster:
+
+```
+helm install k8s-source deployments/overmind-kube-source
+```
+
+Removing the chart:
+
+```
+helm uninstall k8s-source
+```

--- a/deployments/overmind-kube-source/README.md
+++ b/deployments/overmind-kube-source/README.md
@@ -5,7 +5,7 @@
 Installing into a local cluster:
 
 ```
-helm install k8s-source deployments/overmind-kube-source
+helm install k8s-source deployments/overmind-kube-source --set source.natsJWT=REPLACEME,source.natsNKeySeed=REPLACEME
 ```
 
 Removing the chart:

--- a/deployments/overmind-kube-source/templates/NOTES.txt
+++ b/deployments/overmind-kube-source/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Some stuff goes here
+
+NOTES.txt

--- a/deployments/overmind-kube-source/templates/NOTES.txt
+++ b/deployments/overmind-kube-source/templates/NOTES.txt
@@ -1,3 +1,1 @@
-Some stuff goes here
-
-NOTES.txt
+The overmind source has now been installed ✅

--- a/deployments/overmind-kube-source/templates/_helpers.tpl
+++ b/deployments/overmind-kube-source/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "overmind-kube-source.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "overmind-kube-source.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "overmind-kube-source.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "overmind-kube-source.labels" -}}
+helm.sh/chart: {{ include "overmind-kube-source.chart" . }}
+{{ include "overmind-kube-source.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "overmind-kube-source.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "overmind-kube-source.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "overmind-kube-source.serviceAccountName" -}}
+{{- default (include "overmind-kube-source.fullname" .) .Values.serviceAccount.name }}
+{{- end }}
+
+{{/*
+Create the name of the cluster role to use
+*/}}
+{{- define "overmind-kube-source.clusterRoleName" -}}
+{{- default (include "overmind-kube-source.fullname" .) }}
+{{- end }}
+
+{{/*
+Create the name of the cluster role binidng to use
+*/}}
+{{- define "overmind-kube-source.clusterRoleBindingName" -}}
+{{- default (include "overmind-kube-source.fullname" .) }}
+{{- end }}

--- a/deployments/overmind-kube-source/templates/clusterrole.yaml
+++ b/deployments/overmind-kube-source/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "overmind-kube-source.clusterRoleName" . }}
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]

--- a/deployments/overmind-kube-source/templates/clusterrolebinding.yaml
+++ b/deployments/overmind-kube-source/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "overmind-kube-source.clusterRoleBindingName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "overmind-kube-source.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "overmind-kube-source.clusterRoleName" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/deployments/overmind-kube-source/templates/configmap.yaml
+++ b/deployments/overmind-kube-source/templates/configmap.yaml
@@ -1,0 +1,11 @@
+---
+# ConfigMap definition
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "overmind-kube-source.fullname" . }}-config
+data:
+  LOG: {{ .Values.source.log }}
+  MAX_PARALLEL: {{ .Values.source.maxParallel | quote }}
+  NATS_SERVERS: {{ join "," .Values.source.natsServers }}
+---

--- a/deployments/overmind-kube-source/templates/deployment.yaml
+++ b/deployments/overmind-kube-source/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "overmind-kube-source.fullname" . }}
+  labels:
+    {{- include "overmind-kube-source.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "overmind-kube-source.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "overmind-kube-source.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "overmind-kube-source.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "overmind-kube-source.fullname" . }}-config
+            - secretRef:
+                name: {{ include "overmind-kube-source.fullname" . }}-secrets
+          # TODO: Configure the health check
+          # livenessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          # readinessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployments/overmind-kube-source/templates/hpa.yaml
+++ b/deployments/overmind-kube-source/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "overmind-kube-source.fullname" . }}
+  labels:
+    {{- include "overmind-kube-source.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "overmind-kube-source.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployments/overmind-kube-source/templates/secret.yaml
+++ b/deployments/overmind-kube-source/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "overmind-kube-source.fullname" . }}-secrets
+type: Opaque
+data:
+{{- if .Values.source.natsJWT }}
+  NATS_JWT: {{ .Values.source.natsJWT | b64enc }}
+{{- end }}
+{{- if .Values.source.natsNKeySeed }}
+  NATS_NKEY_SEED: {{ .Values.source.natsNKeySeed | b64enc }}
+{{- end }}

--- a/deployments/overmind-kube-source/templates/serviceaccount.yaml
+++ b/deployments/overmind-kube-source/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "overmind-kube-source.serviceAccountName" . }}
+  labels:
+    {{- include "overmind-kube-source.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/deployments/overmind-kube-source/values.yaml
+++ b/deployments/overmind-kube-source/values.yaml
@@ -1,0 +1,82 @@
+# Default values for overmind-kube-source.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/overmindtech/k8s-source
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+clusterRole:
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Annotations to add to the cluster role
+  annotations: {}
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Source config
+source:
+  # The log level for the source (info, debug, trace etc.)
+  log: info
+  # The list of NATS servers to connect to
+  natsServers:
+    - nats://nats:4222
+    - nats://nats:4223
+  # The JWT token to use to connect to the NATS server
+  natsJWT: ""
+  # The seed to use to generate the NKeys
+  natsNKeySeed: ""
+  # How many requests to run in parallel
+  maxParallel: 20

--- a/sources/endpoints_test.go
+++ b/sources/endpoints_test.go
@@ -67,7 +67,7 @@ func TestEndpointsSource(t *testing.T) {
 			{
 				ExpectedType:   "Node",
 				ExpectedMethod: sdp.QueryMethod_GET,
-				ExpectedQuery:  "k8s-source-tests-control-plane",
+				ExpectedQuery:  "local-tests-control-plane",
 				ExpectedScope:  CurrentCluster.Name,
 			},
 			{

--- a/sources/endpointslice_test.go
+++ b/sources/endpointslice_test.go
@@ -67,7 +67,7 @@ func TestEndpointSliceSource(t *testing.T) {
 			{
 				ExpectedType:   "Node",
 				ExpectedMethod: sdp.QueryMethod_GET,
-				ExpectedQuery:  "k8s-source-tests-control-plane",
+				ExpectedQuery:  "local-tests-control-plane",
 				ExpectedScope:  CurrentCluster.Name,
 			},
 			{

--- a/sources/node_test.go
+++ b/sources/node_test.go
@@ -17,7 +17,7 @@ func TestNodeSource(t *testing.T) {
 
 	st := SourceTests{
 		Source:   source,
-		GetQuery: "k8s-source-tests-control-plane",
+		GetQuery: "local-tests-control-plane",
 		GetScope: sd.String(),
 		GetQueryTests: QueryTests{
 			{

--- a/sources/shared_test.go
+++ b/sources/shared_test.go
@@ -74,7 +74,7 @@ func (t *TestCluster) ConnectExisting(name string) error {
 }
 
 func (t *TestCluster) Start() error {
-	clusterName := "k8s-source-tests"
+	clusterName := "local-tests"
 
 	log.Println("🔍 Trying to connect to existing cluster")
 	err := t.ConnectExisting(clusterName)

--- a/sources/volumeattachment_test.go
+++ b/sources/volumeattachment_test.go
@@ -53,7 +53,7 @@ kind: VolumeAttachment
 metadata:
   name: volume-attachment-attachment
 spec:
-  nodeName: k8s-source-tests-control-plane
+  nodeName: local-tests-control-plane
   attacher: kubernetes.io
   source:
     persistentVolumeName: volume-attachment-pv
@@ -82,7 +82,7 @@ func TestVolumeAttachmentSource(t *testing.T) {
 			{
 				ExpectedType:   "Node",
 				ExpectedMethod: sdp.QueryMethod_GET,
-				ExpectedQuery:  "k8s-source-tests-control-plane",
+				ExpectedQuery:  "local-tests-control-plane",
 				ExpectedScope:  sd.String(),
 			},
 		},


### PR DESCRIPTION
This creates a helm chart to deploy this source. It assumes that the user is going to supply an NKey and Token which in the long term doesn't make a whole lot of sense, but I'm going to track the connecting and auth stuff in another ticket as it's a fairly big job