### PR TITLE
Added discarding for empty events

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -293,6 +293,15 @@ var rootCmd = &cobra.Command{
 
 				os.Exit(0)
 			case event := <-restart:
+				if event.Type == "" {
+					// Discard empty events. After a certain period kubernetes
+					// starts sending occasional empty events, I can't work out why,
+					// maybe it's to keep the connection open. Either way they don't
+					// represent anything and should be discarded
+					log.Debug("Discarding empty event")
+					continue
+				}
+
 				log.Infof("Restarting engine due to namespace event: %v", event.Type)
 
 				// Stop the engine


### PR DESCRIPTION
I can't find anything on google about this behavior. I've logged everything and there's nothing in them at all, neither in the Type or the Object fields. Seems safe to discard