### PR TITLE
Moved sentry and tracing init to be conditional

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -509,16 +509,23 @@ func init() {
 			}
 		})
 
-		honeycomb_api_key := viper.GetString("honeycomb-api-key")
-		tracingOpts := make([]otlptracehttp.Option, 0)
-		if honeycomb_api_key != "" {
-			tracingOpts = []otlptracehttp.Option{
-				otlptracehttp.WithEndpoint("api.honeycomb.io"),
-				otlptracehttp.WithHeaders(map[string]string{"x-honeycomb-team": honeycomb_api_key}),
+		if sentryDSN := viper.GetString("sentry-dsn"); sentryDSN != "" {
+			err := initSentry(sentryDSN)
+
+			if err != nil {
+				log.Errorf("error initializing sentry: %s", err)
 			}
 		}
-		if err := initTracing(tracingOpts...); err != nil {
-			log.Fatal(err)
+
+		if honeycombAPIKey := viper.GetString("honeycomb-api-key"); honeycombAPIKey != "" {
+			tracingOpts := []otlptracehttp.Option{
+				otlptracehttp.WithEndpoint("api.honeycomb.io"),
+				otlptracehttp.WithHeaders(map[string]string{"x-honeycomb-team": honeycombAPIKey}),
+			}
+
+			if err := initOtel(tracingOpts...); err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 

--- a/cmd/tracing.go
+++ b/cmd/tracing.go
@@ -98,33 +98,35 @@ func tracingResource() *resource.Resource {
 
 var tp *sdktrace.TracerProvider
 
-func initTracing(opts ...otlptracehttp.Option) error {
-	if sentry_dsn := viper.GetString("sentry-dsn"); sentry_dsn != "" {
-		var environment string
-		if viper.GetString("run-mode") == "release" {
-			environment = "prod"
-		} else {
-			environment = "dev"
-		}
-		err := sentry.Init(sentry.ClientOptions{
-			Dsn:              sentry_dsn,
-			AttachStacktrace: true,
-			EnableTracing:    false,
-			Environment:      environment,
-			// Set TracesSampleRate to 1.0 to capture 100%
-			// of transactions for performance monitoring.
-			// We recommend adjusting this value in production,
-			TracesSampleRate: 1.0,
-		})
-		if err != nil {
-			log.Errorf("sentry.Init: %s", err)
-		}
-		// setup recovery for an unexpected panic in this function
-		defer sentry.Flush(2 * time.Second)
-		defer sentry.Recover()
-		log.Info("sentry configured")
+func initSentry(sentryDSN string) error {
+	var environment string
+	if viper.GetString("run-mode") == "release" {
+		environment = "prod"
+	} else {
+		environment = "dev"
 	}
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn:              sentryDSN,
+		AttachStacktrace: true,
+		EnableTracing:    false,
+		Environment:      environment,
+		// Set TracesSampleRate to 1.0 to capture 100%
+		// of transactions for performance monitoring.
+		// We recommend adjusting this value in production,
+		TracesSampleRate: 1.0,
+	})
+	if err != nil {
+		log.Errorf("sentry.Init: %s", err)
+	}
+	// setup recovery for an unexpected panic in this function
+	defer sentry.Flush(2 * time.Second)
+	defer sentry.Recover()
+	log.Info("sentry configured")
 
+	return nil
+}
+
+func initOtel(opts ...otlptracehttp.Option) error {
 	// for stdout debugging of traces
 	// stdoutExp, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
 	// if err != nil {


### PR DESCRIPTION
This means that when a customer is running the source locally, it won't try to init sentry or tracing. This is because the customer won't have the necessary environment variables set up, and therefore won't get annoying errors