### PR TITLE
Added heartbeat functionality

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,6 +27,10 @@ jobs:
         run: |
           go get -v -t -d ./...
 
+      - name: Go Generate
+        run: |
+          go generate ./...
+
       - name: Vet
         run: go vet ./...
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,6 +27,9 @@ jobs:
         run: |
           go get -v -t -d ./...
 
+      - name: Install Docgen
+        run: go install github.com/overmindtech/docgen@latest
+
       - name: Go Generate
         run: |
           go generate ./...

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ output
 vendor
 Gopkg.lock
 build/compiled
+commit.txt

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -20,7 +20,8 @@ COPY sources/ sources/
 
 # Build
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -trimpath -o source main.go
+    go generate ./... \
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -trimpath -o source main.go
 
 FROM alpine:3.20
 WORKDIR /

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -18,6 +18,8 @@ COPY main.go main.go
 COPY cmd/ cmd/
 COPY sources/ sources/
 
+RUN go install github.com/overmindtech/docgen@latest
+
 # Build
 RUN --mount=type=cache,target=/root/.cache/go-build \
     go generate ./... \

--- a/cmd/tracing.go
+++ b/cmd/tracing.go
@@ -18,6 +18,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	_ "embed"
 )
 
 // for stdout debugging of traces
@@ -34,6 +36,10 @@ import (
 // 		trace.WithInstrumentationVersion(instrumentationVersion),
 // 		trace.WithSchemaURL(semconv.SchemaURL),
 // 	)
+
+//go:generate sh -c "echo -n $(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD) > commit.txt"
+//go:embed commit.txt
+var ServiceVersion string
 
 func tracingResource() *resource.Resource {
 	// Identify your application using resource detection
@@ -77,7 +83,7 @@ func tracingResource() *resource.Resource {
 		// Add your own custom attributes to identify your application
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("k8s-source"),
-			semconv.ServiceVersionKey.String("0.0.1"),
+			semconv.ServiceVersionKey.String(ServiceVersion),
 		),
 	)
 	if err != nil {

--- a/deployments/overmind-kube-source/templates/configmap.yaml
+++ b/deployments/overmind-kube-source/templates/configmap.yaml
@@ -7,14 +7,14 @@ metadata:
 data:
   LOG: {{ .Values.source.log }}
   MAX_PARALLEL: {{ .Values.source.maxParallel | quote }}
-  NATS_SERVERS: {{ join "," .Values.source.natsServers }}
+  SOURCE_NAME: {{ .Chart.Name }}
   RATE_LIMIT_QPS: {{ .Values.source.rateLimitQPS | quote }}
   RATE_LIMIT_BURST: {{ .Values.source.rateLimitBurst | quote }}
 {{- if .Values.source.clusterName }}
   CLUSTER_NAME: {{ .Values.source.clusterName | quote }}
 {{- end }}
-{{- if .Values.source.apiPath }}
-  API_PATH: {{ .Values.source.apiPath | quote }}
+{{- if .Values.source.app }}
+  APP: {{ .Values.source.app | quote }}
 {{- end }}
 {{- if .Values.source.honeycombApiKey }}
   HONEYCOMB_API_KEY: {{ .Values.source.honeycombApiKey | quote }}

--- a/deployments/overmind-kube-source/templates/deployment.yaml
+++ b/deployments/overmind-kube-source/templates/deployment.yaml
@@ -38,15 +38,21 @@ spec:
                 name: {{ include "overmind-kube-source.fullname" . }}-config
             - secretRef:
                 name: {{ include "overmind-kube-source.fullname" . }}-secrets
-          # TODO: Configure the health check
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          env:
+            - name: HEALTH_CHECK_PORT
+              value: "8080"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deployments/overmind-kube-source/values.yaml
+++ b/deployments/overmind-kube-source/values.yaml
@@ -70,13 +70,10 @@ affinity: {}
 source:
   # The log level for the source (info, debug, trace etc.)
   log: info
-  # The list of NATS servers to connect to
-  natsServers:
-    - wss://messages.app.overmind.tech
   # The API key used to connect to Overmind
   apiKey: ""
-  # The API to use
-  apiPath: ""
+  # The URL of the Overmind instance to connect to
+  app: "https://app.overmind.tech"
   # How many requests to run in parallel
   maxParallel: 20
   # The maximum sustained queries per second from this source to the kubernetes API


### PR DESCRIPTION
The `api-path` parameter has been removed and replaced with the `app` parameter, which should now be set to the URL that you use to access Overmind

The `nats-servers` parameter has been removed, as this is now set automatically.

Fixes #285


Once this is merged we will need to:

* [ ] Bump the helm version
* [ ] Deploy this new version using Terraform
* [ ] Remember to change the `apiURL` parameter to `app`