### PR TITLE
(fix) add CrashLoopBackOff, to list of waiting container errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 redacted_cli
 .DS_Store
-__debug_bin
+__debug_bin*
 .vagrant
 output
 vendor

--- a/adapters/pods.go
+++ b/adapters/pods.go
@@ -377,7 +377,7 @@ func hasWaitingContainerErrors(containerStatuses []v1.ContainerStatus) bool {
 	for _, c := range containerStatuses {
 		if c.State.Waiting != nil {
 			// list of image errors from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/images/types.go#L27-L42
-			if slices.Contains([]string{"ImagePullBackOff", "ImageInspectError", "ErrImagePull", "ErrImageNeverPull", "InvalidImageName"}, c.State.Waiting.Reason) {
+			if slices.Contains([]string{"CrashLoopBackOff", "ImagePullBackOff", "ImageInspectError", "ErrImagePull", "ErrImageNeverPull", "InvalidImageName"}, c.State.Waiting.Reason) {
 				return true
 			}
 		}


### PR DESCRIPTION
https://github.com/overmindtech/k8s-source/issues/309

after waiting minutes i was manually able to trigger this edge case. Adding it to the list